### PR TITLE
fix: use "X-Forwarded-Proto" header for https redirect

### DIFF
--- a/middleware/redirect-to-https.js
+++ b/middleware/redirect-to-https.js
@@ -1,7 +1,9 @@
 const HttpStatus = require('http-status-codes');
 
 module.exports = function redirectToHttps(req, res, next) {
-  if (req.protocol === 'http' && process.env.NODE_ENV === 'production') {
+  const forwardedProtocol = req.get('X-Forwarded-Proto');
+
+  if (forwardedProtocol === 'http' && process.env.NODE_ENV === 'production') {
     const redirectUrl = new URL(req.originalUrl, `https://${req.get('host')}`);
     return res.redirect(HttpStatus.MOVED_PERMANENTLY, redirectUrl.toString());
   }


### PR DESCRIPTION
req.protocol is always "http" because of the Express app is
behind a reverse proxy that handles TLS